### PR TITLE
geom_alt props

### DIFF
--- a/data/421/184/383/421184383.geojson
+++ b/data/421/184/383/421184383.geojson
@@ -211,6 +211,9 @@
     },
     "wof:country":"KW",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"d227296b1daebed33f066c6bb1e33c32",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":421184383,
-    "wof:lastmodified":1566591072,
+    "wof:lastmodified":1582331169,
     "wof:name":"East Hawalli",
     "wof:parent_id":85673405,
     "wof:placetype":"locality",

--- a/data/421/202/465/421202465.geojson
+++ b/data/421/202/465/421202465.geojson
@@ -589,6 +589,9 @@
     },
     "wof:country":"KW",
     "wof:created":1459010119,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85c31f63f736ae8a916ed6bb77495ce6",
     "wof:hierarchy":[
         {
@@ -599,7 +602,7 @@
         }
     ],
     "wof:id":421202465,
-    "wof:lastmodified":1566591065,
+    "wof:lastmodified":1582331168,
     "wof:name":"Kuwait City",
     "wof:parent_id":85673383,
     "wof:placetype":"locality",

--- a/data/856/324/01/85632401.geojson
+++ b/data/856/324/01/85632401.geojson
@@ -921,6 +921,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -975,6 +976,10 @@
     },
     "wof:country":"KW",
     "wof:country_alpha3":"KWT",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"74271311b4f52ffbf7d535f7cd5c0e25",
     "wof:hierarchy":[
         {
@@ -989,7 +994,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566591058,
+    "wof:lastmodified":1582331168,
     "wof:name":"Kuwait",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/01/85632401.geojson
+++ b/data/856/324/01/85632401.geojson
@@ -921,7 +921,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -994,7 +993,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582331168,
+    "wof:lastmodified":1583213894,
     "wof:name":"Kuwait",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/859/030/23/85903023.geojson
+++ b/data/859/030/23/85903023.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":996419
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb61c18bd567cf5ffa65c443e84a9f3c",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"Al Adiliyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/25/85903025.geojson
+++ b/data/859/030/25/85903025.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1168201
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e2df21e7a6145c8b67ee2e7939e724b",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"As S\u0101lih\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/27/85903027.geojson
+++ b/data/859/030/27/85903027.geojson
@@ -103,6 +103,10 @@
         "wk:page":"Sulaibikhat"
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ecfc7ff37ebb5625f975454696051d6",
     "wof:hierarchy":[
         {
@@ -117,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"As Sulaybikhat",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/31/85903031.geojson
+++ b/data/859/030/31/85903031.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":233042
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ec653ff09a0bfa93775812672b7aa56",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"Bunayd al Q\u00e5r",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/85/85904185.geojson
+++ b/data/859/041/85/85904185.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1208215
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3808d2b04f2d314e8e7e04601a360919",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"\u0627\u0644\u0634\u0648\u064a\u062e \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/87/85904187.geojson
+++ b/data/859/041/87/85904187.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":233606
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c3618e10f941b1cfb5b883c389292eb",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"Mina`a Al-shuwakh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/89/85904189.geojson
+++ b/data/859/041/89/85904189.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1119164
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"872249cc26c99445fc258da1209cf2cb",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"Dasman",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/45/85907245.geojson
+++ b/data/859/072/45/85907245.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":507981
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"26ea50408af0737312d7ba8d6f5f414a",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"Abdullah As Salem",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/47/85907247.geojson
+++ b/data/859/072/47/85907247.geojson
@@ -86,6 +86,10 @@
         "wd:id":"Q12236750"
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef7c6a1af3524f28dc0541369338552c",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"Keifan",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/49/85907249.geojson
+++ b/data/859/072/49/85907249.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":43493
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"433dcf17ed703d6f1a4df262463797bb",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"\u0628\u0646\u064a\u062f \u0627\u0644\u0642\u0627\u0631",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/51/85907251.geojson
+++ b/data/859/072/51/85907251.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":233684
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8176a65a2e42907eaf63306cda517cee",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"Jabriya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/53/85907253.geojson
+++ b/data/859/072/53/85907253.geojson
@@ -363,6 +363,10 @@
         "qs_pg:id":508052
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef95930a563cc3254b9291bb4628c29a",
     "wof:hierarchy":[
         {
@@ -377,7 +381,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"Granada",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/55/85907255.geojson
+++ b/data/859/072/55/85907255.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":233685
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"91abf3e5dd2c79947e07e1872b19168f",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"Bloush",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/13/85932313.geojson
+++ b/data/859/323/13/85932313.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":18215
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82d10c97f095e4634d3c9f52c96a7e9b",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331167,
     "wof:name":"Fahaheel-block 10",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/17/85932317.geojson
+++ b/data/859/323/17/85932317.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":230858
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7b282260e169b9540371404eac06db4",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"\u0627\u0644\u0633\u0641\u0627\u0631\u0627\u062a",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/25/85932325.geojson
+++ b/data/859/323/25/85932325.geojson
@@ -65,6 +65,10 @@
         "qs_pg:id":505413
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"212da01f1748d842ae8747ce6dc07c7b",
     "wof:hierarchy":[
         {
@@ -79,7 +83,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331167,
     "wof:name":"Salmiya-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/29/85932329.geojson
+++ b/data/859/323/29/85932329.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1188460
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"645d08e4e21602ec84380a28d0941380",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Jabriya-block 8",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/35/85932335.geojson
+++ b/data/859/323/35/85932335.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1188461
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b9d3dcc1dd99acef922b7b0fac32621a",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Farwaniyah-block 6",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/39/85932339.geojson
+++ b/data/859/323/39/85932339.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":991488
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f243fbaddd4c6d917e427e87501d4a2",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Rawda-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/43/85932343.geojson
+++ b/data/859/323/43/85932343.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1188459
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d437bc6cff32a9af98c3dfa29f5a755",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"\u0627\u0644\u0633\u0627\u0644\u0645\u064a\u0629-\u0642\u0637\u0639\u0629 13",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/47/85932347.geojson
+++ b/data/859/323/47/85932347.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":888769
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"634b01de16598115d593265868819537",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331167,
     "wof:name":"\u0627\u0644\u0645\u0631\u0642\u0627\u0628-\u0642\u0637\u0639\u0629 6",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/53/85932353.geojson
+++ b/data/859/323/53/85932353.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":991489
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9139897af8f1b8604efa129b4bdbc922",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Bayan-block 6",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/57/85932357.geojson
+++ b/data/859/323/57/85932357.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":68213
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"18fd7588e274deb2ea6b01917afc2257",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Farwaniyah-block 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/61/85932361.geojson
+++ b/data/859/323/61/85932361.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":991491
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0c101534cdb5124a3d301a5961d0a8eb",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Nuzha-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/65/85932365.geojson
+++ b/data/859/323/65/85932365.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":962307
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ef9a05081cb09d3f38d63c63b73955b",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Khaldiya-block 4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/71/85932371.geojson
+++ b/data/859/323/71/85932371.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":523668
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a69be57c31f0cb7a4a240d8384dcb8cc",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Salmiya-block 8",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/75/85932375.geojson
+++ b/data/859/323/75/85932375.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":961499
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f566dedbd29f1ef6a4a4cfd5b0f2cc3b",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Al Qurain-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/79/85932379.geojson
+++ b/data/859/323/79/85932379.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":260545
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fde99dc7498efe8c5b9882fe386e6341",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Fintas-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/83/85932383.geojson
+++ b/data/859/323/83/85932383.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":214680
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0b163d3bcccf97a01e05769ff0c70bc3",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Salwa-block 7",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/89/85932389.geojson
+++ b/data/859/323/89/85932389.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":230860
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce2463b0d58c23437b6d7e3b54f871ec",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Sha'ab-block 8",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/93/85932393.geojson
+++ b/data/859/323/93/85932393.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":383467
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f756ecbd3484c505d05d3bfe45b981fa",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Salmiya-block 11",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/95/85932395.geojson
+++ b/data/859/323/95/85932395.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":961501
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d040fce480dddbd4c634f901399a509",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Mishref-block 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/99/85932399.geojson
+++ b/data/859/323/99/85932399.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":961502
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae46d2d290a7e8aafde695ef501929f3",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591054,
+    "wof:lastmodified":1582331167,
     "wof:name":"Yarmouk-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/03/85932403.geojson
+++ b/data/859/324/03/85932403.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":961503
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"569589b98f7580448ddc6d0cd8074f15",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331166,
     "wof:name":"Mubarak Al Kabeer-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/09/85932409.geojson
+++ b/data/859/324/09/85932409.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":992640
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb6b46b96d543220c30b0d93a564a9cd",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331167,
     "wof:name":"Salhiya-block 5",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/13/85932413.geojson
+++ b/data/859/324/13/85932413.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1295850
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e251a7182cfda14715f477c03fb997b4",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Jabriya-block 9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/17/85932417.geojson
+++ b/data/859/324/17/85932417.geojson
@@ -68,6 +68,9 @@
         "gp:id":55943276
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0728d834f36127fdd0417d9a4958d03a",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":85932417,
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331167,
     "wof:name":"Koeweit Stad",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/21/85932421.geojson
+++ b/data/859/324/21/85932421.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1323426
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e6039377883d74d078fbd5f000e9e900",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331167,
     "wof:name":"Zahra-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/27/85932427.geojson
+++ b/data/859/324/27/85932427.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":233881
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ad72b66a447085319fc963f1f6c6158",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331166,
     "wof:name":"\u0627\u0644\u0642\u0628\u0644\u0629-\u0642\u0637\u0639\u0629 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/31/85932431.geojson
+++ b/data/859/324/31/85932431.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1295851
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7623dd029429120d67ac018363a1a9a6",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331167,
     "wof:name":"Dasma-block 5",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/39/85932439.geojson
+++ b/data/859/324/39/85932439.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":975379
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98bd00013f23b0adaa769ba0584ea4ba",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Qasr-block 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/45/85932445.geojson
+++ b/data/859/324/45/85932445.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":233882
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c017a1e6e51aec296601355038940ea",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331166,
     "wof:name":"Dasman-block 13",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/49/85932449.geojson
+++ b/data/859/324/49/85932449.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":233883
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"002792c7d00f815fd89a29a1542146bb",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Abu Halifa-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/53/85932453.geojson
+++ b/data/859/324/53/85932453.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1119981
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f77cc35d1c4632870e2af2c80d71e618",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Zahra-block 8",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/57/85932457.geojson
+++ b/data/859/324/57/85932457.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":975382
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"57c9283f3f54c87b7e896ba54d42a6ee",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591051,
+    "wof:lastmodified":1582331166,
     "wof:name":"Rawda-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/63/85932463.geojson
+++ b/data/859/324/63/85932463.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":888410
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90c7fb22ebe4b8cd5cd1eb0a1edf22df",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Qurtuba-block 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/67/85932467.geojson
+++ b/data/859/324/67/85932467.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":383466
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1110362f1dc65f071bccf23331f5b54c",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331166,
     "wof:name":"Salmiya-block 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/71/85932471.geojson
+++ b/data/859/324/71/85932471.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":959673
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"84d6475fc71b6816194f33153f20b0bb",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Al Salam-block 7",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/75/85932475.geojson
+++ b/data/859/324/75/85932475.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":973303
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82446e94083c2a10c0c48d66859e9ed4",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331167,
     "wof:name":"Hateen-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/83/85932483.geojson
+++ b/data/859/324/83/85932483.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1316616
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2358bbfc400551e3c35fd5cb7eb5652e",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591053,
+    "wof:lastmodified":1582331167,
     "wof:name":"Qurtuba-block 4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/87/85932487.geojson
+++ b/data/859/324/87/85932487.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":467837
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"66c5e6501e364ab8a1c3fa21bec0277c",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331167,
     "wof:name":"Salmiya-block 10",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/324/91/85932491.geojson
+++ b/data/859/324/91/85932491.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":467835
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6aa651c1e8c4707b58f3d226529af36a",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591052,
+    "wof:lastmodified":1582331167,
     "wof:name":"Omariyah-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/01/85932501.geojson
+++ b/data/859/325/01/85932501.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":986745
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d1807e359419df7a42ed2c34509870c0",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Salwa-block 12",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/05/85932505.geojson
+++ b/data/859/325/05/85932505.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":986746
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"272d5c2f6953c4516730ea6c21cc3edd",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331168,
     "wof:name":"Manqaf-block 4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/09/85932509.geojson
+++ b/data/859/325/09/85932509.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":986747
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d71cb453d94472f89130a53d240d624a",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"\u0634\u0631\u0642-\u0642\u0637\u0639\u0629 8",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/15/85932515.geojson
+++ b/data/859/325/15/85932515.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":986748
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfe3bcff1e89311be1a119a5c3ea6c5a",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"Sabah Al Salem-block 6",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/19/85932519.geojson
+++ b/data/859/325/19/85932519.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":986749
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e91d697bf5d9d8eb50653d383b4a84d",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Salwa-block 9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/23/85932523.geojson
+++ b/data/859/325/23/85932523.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":986750
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3900324befce74a9e3924f4d5b9d811b",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"\u0627\u0644\u0645\u0633\u064a\u0644\u0629-\u0642\u0637\u0639\u0629 41",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/27/85932527.geojson
+++ b/data/859/325/27/85932527.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":523698
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73385841f6e0158489579d543e9cff1f",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331168,
     "wof:name":"Yarmouk-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/37/85932537.geojson
+++ b/data/859/325/37/85932537.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":383474
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"451cde8e36f95e5737238f5a767a5d2c",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Granada-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/41/85932541.geojson
+++ b/data/859/325/41/85932541.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":383476
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd03560864546953396628605eb3b36d",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Fintas-block 3",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/45/85932545.geojson
+++ b/data/859/325/45/85932545.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1295859
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1777e24d4c8b74d38f6937ac5c911dc0",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331168,
     "wof:name":"Yarmouk-block 4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/51/85932551.geojson
+++ b/data/859/325/51/85932551.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":523725
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f539ed0c554c3adcfd0278e7b0293f1",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331168,
     "wof:name":"Mishref-block 5",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/53/85932553.geojson
+++ b/data/859/325/53/85932553.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1295860
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ca08c14f8457aab0fd86d5f2fa2be06",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Rumaithiya-block 7",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/59/85932559.geojson
+++ b/data/859/325/59/85932559.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":467838
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc588d0764083c25e9b982b5a35b0d79",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331167,
     "wof:name":"Sabah Al Salem-block 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/63/85932563.geojson
+++ b/data/859/325/63/85932563.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":225229
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38c33c54fbc972991ee6cf2b4c234d82",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"\u0633\u0648\u0642 \u0634\u0631\u0642",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/65/85932565.geojson
+++ b/data/859/325/65/85932565.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1316628
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c52283b1cc3c00184ac2bd22d142f90e",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Omariyah-block 2",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/75/85932575.geojson
+++ b/data/859/325/75/85932575.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":225553
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21c1510b418c3079df6c3ad22bc95fa6",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Sawaber-block 10",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/79/85932579.geojson
+++ b/data/859/325/79/85932579.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":986751
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7bdef5ad5fc4e2c554d110850cd69d0",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591056,
+    "wof:lastmodified":1582331168,
     "wof:name":"Manqaf-block 1",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/83/85932583.geojson
+++ b/data/859/325/83/85932583.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1090210
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c580dc607163405d4a9a293d3e328fb6",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591057,
+    "wof:lastmodified":1582331168,
     "wof:name":"Al Rabiah-block 4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/89/85932589.geojson
+++ b/data/859/325/89/85932589.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":383475
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d331a82f3b8f49313021c2515aab0836",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331168,
     "wof:name":"Mishref-block 8",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/325/93/85932593.geojson
+++ b/data/859/325/93/85932593.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1090211
     },
     "wof:country":"KW",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f68227441fdb3b060701ef0736c3be9",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566591055,
+    "wof:lastmodified":1582331168,
     "wof:name":"Fahaheel-block 12",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.