### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/171/123/421171123.geojson
+++ b/data/421/171/123/421171123.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0647\u062f\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shuhada"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421171123,
-    "wof:lastmodified":1566591075,
-    "wof:name":"\u0627\u0644\u0634\u0647\u062f\u0627\u0621",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shuhada",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/171/123/421171123.geojson
+++ b/data/421/171/123/421171123.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421171123,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shuhada",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",

--- a/data/421/172/941/421172941.geojson
+++ b/data/421/172/941/421172941.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u0648\u0644\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Hawalli"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421172941,
-    "wof:lastmodified":1566591067,
-    "wof:name":"\u062d\u0648\u0644\u0649",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Hawalli",
     "wof:parent_id":85673405,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/172/941/421172941.geojson
+++ b/data/421/172/941/421172941.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"48.019351,29.3383385,48.019351,29.3383385",
+    "geom:bbox":"48.019351,29.338338,48.019351,29.338338",
     "geom:latitude":29.338338,
     "geom:longitude":48.019351,
     "iso:country":"KW",
@@ -54,7 +54,7 @@
     },
     "wof:country":"KW",
     "wof:created":1459008960,
-    "wof:geomhash":"8311a9d08a0314b716c2bb593e3bbb41",
+    "wof:geomhash":"0cdb3af4bd737cfc397f7ac8f02a1550",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421172941,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hawalli",
     "wof:parent_id":85673405,
     "wof:placetype":"locality",
@@ -75,9 +75,9 @@
 },
   "bbox": [
     48.019351,
-    29.3383385,
+    29.338338,
     48.019351,
-    29.3383385
+    29.338338
 ],
-  "geometry": {"coordinates":[48.019351,29.3383385],"type":"Point"}
+  "geometry": {"coordinates":[48.019351,29.338338],"type":"Point"}
 }

--- a/data/421/175/635/421175635.geojson
+++ b/data/421/175/635/421175635.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"47.7410885,29.1025925,47.7410885,29.1025925",
+    "geom:bbox":"47.741088,29.102593,47.741088,29.102593",
     "geom:latitude":29.102593,
     "geom:longitude":47.741088,
     "iso:country":"KW",
@@ -54,7 +54,7 @@
     },
     "wof:country":"KW",
     "wof:created":1459009074,
-    "wof:geomhash":"eb02b7668fe4f7a1bc64648b5f0a33db",
+    "wof:geomhash":"01a77e079d71f4b699f7eec95a8a4504",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421175635,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kabed",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",
@@ -74,10 +74,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    47.7410885,
-    29.1025925,
-    47.7410885,
-    29.1025925
+    47.741088,
+    29.102593,
+    47.741088,
+    29.102593
 ],
-  "geometry": {"coordinates":[47.7410885,29.1025925],"type":"Point"}
+  "geometry": {"coordinates":[47.741088,29.102593],"type":"Point"}
 }

--- a/data/421/175/635/421175635.geojson
+++ b/data/421/175/635/421175635.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0628\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Kabed"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421175635,
-    "wof:lastmodified":1566591068,
-    "wof:name":"\u0643\u0628\u062f",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kabed",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/177/963/421177963.geojson
+++ b/data/421/177/963/421177963.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u062f\u064a\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Sadik"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421177963,
-    "wof:lastmodified":1566591073,
-    "wof:name":"\u0635\u062f\u064a\u0642",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sadik",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/177/963/421177963.geojson
+++ b/data/421/177/963/421177963.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421177963,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sadik",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",

--- a/data/421/180/935/421180935.geojson
+++ b/data/421/180/935/421180935.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421180935,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Al Hayman",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/180/935/421180935.geojson
+++ b/data/421/180/935/421180935.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u0627\u0644\u0647\u064a\u0645\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Al Hayman"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421180935,
-    "wof:lastmodified":1566591065,
-    "wof:name":"\u0627\u0645 \u0627\u0644\u0647\u064a\u0645\u0627\u0646",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Al Hayman",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/181/617/421181617.geojson
+++ b/data/421/181/617/421181617.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421181617,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Nuwaiseeb",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/181/617/421181617.geojson
+++ b/data/421/181/617/421181617.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0646\u0648\u064a\u0635\u064a\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Nuwaiseeb"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421181617,
-    "wof:lastmodified":1566591067,
-    "wof:name":"\u0646\u0648\u064a\u0635\u064a\u0628",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Nuwaiseeb",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/181/833/421181833.geojson
+++ b/data/421/181/833/421181833.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0635\u0644\u064a\u0628\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "As Sulaibiya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421181833,
-    "wof:lastmodified":1566591067,
-    "wof:name":"\u0627\u0644\u0635\u0644\u064a\u0628\u064a\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"As Sulaibiya",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/181/833/421181833.geojson
+++ b/data/421/181/833/421181833.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"47.789303,29.2534495,47.789303,29.2534495",
+    "geom:bbox":"47.789303,29.253449,47.789303,29.253449",
     "geom:latitude":29.253449,
     "geom:longitude":47.789303,
     "iso:country":"KW",
@@ -54,7 +54,7 @@
     },
     "wof:country":"KW",
     "wof:created":1459009308,
-    "wof:geomhash":"5508323c52e94be8af5e9d502c1b7d8b",
+    "wof:geomhash":"c36375b07f057e9336967d3c1ddedc42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421181833,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423087,
     "wof:name":"As Sulaibiya",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",
@@ -75,9 +75,9 @@
 },
   "bbox": [
     47.789303,
-    29.2534495,
+    29.253449,
     47.789303,
-    29.2534495
+    29.253449
 ],
-  "geometry": {"coordinates":[47.789303,29.2534495],"type":"Point"}
+  "geometry": {"coordinates":[47.789303,29.253449],"type":"Point"}
 }

--- a/data/421/183/087/421183087.geojson
+++ b/data/421/183/087/421183087.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421183087,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Hajeel",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/183/087/421183087.geojson
+++ b/data/421/183/087/421183087.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u062c\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hajeel"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421183087,
-    "wof:lastmodified":1566591074,
-    "wof:name":"\u0627\u0644\u062d\u062c\u064a\u0644",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Hajeel",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/157/421184157.geojson
+++ b/data/421/184/157/421184157.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0628\u0648 \u0627\u0644\u062d\u0635\u0627\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Abu Al Hasaniya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184157,
-    "wof:lastmodified":1566591070,
-    "wof:name":"\u0627\u0628\u0648 \u0627\u0644\u062d\u0635\u0627\u0646\u064a\u0629",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Abu Al Hasaniya",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/157/421184157.geojson
+++ b/data/421/184/157/421184157.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"48.0988305,29.2125595,48.0988305,29.2125595",
+    "geom:bbox":"48.09883,29.21256,48.09883,29.21256",
     "geom:latitude":29.21256,
     "geom:longitude":48.09883,
     "iso:country":"KW",
@@ -54,7 +54,7 @@
     },
     "wof:country":"KW",
     "wof:created":1459009402,
-    "wof:geomhash":"260cd1e4f98f3e5d56a385bab148c3d9",
+    "wof:geomhash":"3ae92eade41a214ca91dc54b12d121d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184157,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423082,
     "wof:name":"Abu Al Hasaniya",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
@@ -74,10 +74,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    48.0988305,
-    29.2125595,
-    48.0988305,
-    29.2125595
+    48.09883,
+    29.21256,
+    48.09883,
+    29.21256
 ],
-  "geometry": {"coordinates":[48.0988305,29.2125595],"type":"Point"}
+  "geometry": {"coordinates":[48.09883,29.21256],"type":"Point"}
 }

--- a/data/421/184/235/421184235.geojson
+++ b/data/421/184/235/421184235.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u062f\u064a\u0644\u064a\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jadeliyyat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184235,
-    "wof:lastmodified":1566591071,
-    "wof:name":"\u0627\u0644\u062c\u062f\u064a\u0644\u064a\u0627\u062a",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jadeliyyat",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/235/421184235.geojson
+++ b/data/421/184/235/421184235.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184235,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jadeliyyat",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",

--- a/data/421/184/363/421184363.geojson
+++ b/data/421/184/363/421184363.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0641\u062d\u064a\u062d\u064a\u0644 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Industrial Fahaheel"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184363,
-    "wof:lastmodified":1566591070,
-    "wof:name":"\u0627\u0644\u0641\u062d\u064a\u062d\u064a\u0644 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Industrial Fahaheel",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/363/421184363.geojson
+++ b/data/421/184/363/421184363.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184363,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423089,
     "wof:name":"Industrial Fahaheel",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/184/435/421184435.geojson
+++ b/data/421/184/435/421184435.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u064a\u062f\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Al Bayda"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184435,
-    "wof:lastmodified":1566591073,
-    "wof:name":"\u0627\u0644\u0628\u064a\u062f\u0627\u0621",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Bayda",
     "wof:parent_id":85673405,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/435/421184435.geojson
+++ b/data/421/184/435/421184435.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184435,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Bayda",
     "wof:parent_id":85673405,
     "wof:placetype":"locality",

--- a/data/421/184/437/421184437.geojson
+++ b/data/421/184/437/421184437.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184437,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khiran",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/184/437/421184437.geojson
+++ b/data/421/184/437/421184437.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062e\u064a\u0631\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Khiran"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184437,
-    "wof:lastmodified":1566591071,
-    "wof:name":"\u062e\u064a\u0631\u0627\u0646",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Khiran",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/441/421184441.geojson
+++ b/data/421/184/441/421184441.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0647\u0628\u0648\u0644\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mahboula"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184441,
-    "wof:lastmodified":1566591071,
-    "wof:name":"\u0627\u0644\u0645\u0647\u0628\u0648\u0644\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mahboula",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/441/421184441.geojson
+++ b/data/421/184/441/421184441.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184441,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mahboula",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/184/443/421184443.geojson
+++ b/data/421/184/443/421184443.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0632\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al Zour"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184443,
-    "wof:lastmodified":1566591072,
-    "wof:name":"\u0627\u0644\u0632\u0648\u0631",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Zour",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/184/443/421184443.geojson
+++ b/data/421/184/443/421184443.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184443,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Zour",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/188/937/421188937.geojson
+++ b/data/421/188/937/421188937.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"48.012342,29.2819815,48.012342,29.2819815",
+    "geom:bbox":"48.012342,29.281982,48.012342,29.281982",
     "geom:latitude":29.281982,
     "geom:longitude":48.012342,
     "iso:country":"KW",
@@ -54,7 +54,7 @@
     },
     "wof:country":"KW",
     "wof:created":1459009588,
-    "wof:geomhash":"66e828feed93923af55939a4236bbcdf",
+    "wof:geomhash":"037a15c04cf9fd3df250fe97e71852c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421188937,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hittin",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",
@@ -75,9 +75,9 @@
 },
   "bbox": [
     48.012342,
-    29.2819815,
+    29.281982,
     48.012342,
-    29.2819815
+    29.281982
 ],
-  "geometry": {"coordinates":[48.012342,29.2819815],"type":"Point"}
+  "geometry": {"coordinates":[48.012342,29.281982],"type":"Point"}
 }

--- a/data/421/188/937/421188937.geojson
+++ b/data/421/188/937/421188937.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u0637\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Hittin"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421188937,
-    "wof:lastmodified":1566591066,
-    "wof:name":"\u062d\u0637\u064a\u0646",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Hittin",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/190/371/421190371.geojson
+++ b/data/421/190/371/421190371.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190371,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Ra",
     "wof:parent_id":85673383,
     "wof:placetype":"locality",

--- a/data/421/190/371/421190371.geojson
+++ b/data/421/190/371/421190371.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Al Ra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190371,
-    "wof:lastmodified":1566591069,
-    "wof:name":"\u0627\u0644\u0631\u0649",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Ra",
     "wof:parent_id":85673383,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/190/373/421190373.geojson
+++ b/data/421/190/373/421190373.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190373,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Wafrah",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/190/373/421190373.geojson
+++ b/data/421/190/373/421190373.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0648\u0641\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Wafrah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190373,
-    "wof:lastmodified":1566591069,
-    "wof:name":"\u0627\u0644\u0648\u0641\u0631\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Wafrah",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/190/375/421190375.geojson
+++ b/data/421/190/375/421190375.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190375,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423082,
     "wof:name":"Abdullah Port",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/190/375/421190375.geojson
+++ b/data/421/190/375/421190375.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u064a\u0646\u0627\u0621 \u0639\u0628\u062f\u0627\u0644\u0644\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Abdullah Port"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190375,
-    "wof:lastmodified":1566591069,
-    "wof:name":"\u0645\u064a\u0646\u0627\u0621 \u0639\u0628\u062f\u0627\u0644\u0644\u0647",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Abdullah Port",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/190/381/421190381.geojson
+++ b/data/421/190/381/421190381.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0627\u062d\u0645\u062f\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Al Ahmadi"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190381,
-    "wof:lastmodified":1566591069,
-    "wof:name":"\u0627\u0644\u0627\u062d\u0645\u062f\u0649",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Al Ahmadi",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/190/381/421190381.geojson
+++ b/data/421/190/381/421190381.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190381,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Ahmadi",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/190/387/421190387.geojson
+++ b/data/421/190/387/421190387.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190387,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jahra",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",

--- a/data/421/190/387/421190387.geojson
+++ b/data/421/190/387/421190387.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u0647\u0631\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jahra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190387,
-    "wof:lastmodified":1566591069,
-    "wof:name":"\u0627\u0644\u062c\u0647\u0631\u0627\u0621",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jahra",
     "wof:parent_id":85673399,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/194/545/421194545.geojson
+++ b/data/421/194/545/421194545.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0641\u0631\u0648\u0627\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Farwaniyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421194545,
-    "wof:lastmodified":1566591062,
-    "wof:name":"\u0627\u0644\u0641\u0631\u0648\u0627\u0646\u064a\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Farwaniyah",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/194/545/421194545.geojson
+++ b/data/421/194/545/421194545.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421194545,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Farwaniyah",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",

--- a/data/421/198/145/421198145.geojson
+++ b/data/421/198/145/421198145.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421198145,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bnaider",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",

--- a/data/421/198/145/421198145.geojson
+++ b/data/421/198/145/421198145.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0646\u064a\u062f\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Bnaider"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421198145,
-    "wof:lastmodified":1566591068,
-    "wof:name":"\u0628\u0646\u064a\u062f\u0631",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bnaider",
     "wof:parent_id":85673391,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",

--- a/data/421/204/587/421204587.geojson
+++ b/data/421/204/587/421204587.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421204587,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sabhan",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",

--- a/data/421/204/587/421204587.geojson
+++ b/data/421/204/587/421204587.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u0628\u062d\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Sabhan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421204587,
-    "wof:lastmodified":1566591063,
-    "wof:name":"\u0635\u0628\u062d\u0627\u0646",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sabhan",
     "wof:parent_id":85673389,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-kw",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.