### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/202/465/421202465.geojson
+++ b/data/421/202/465/421202465.geojson
@@ -606,6 +606,7 @@
         "gn:id":285787,
         "gp:id":1940631,
         "loc:id":"n81102869",
+        "ne:id":1159151361,
         "qs_pg:id":222707,
         "wd:id":"Q35178",
         "wk:page":"Kuwait City"
@@ -625,7 +626,8 @@
         }
     ],
     "wof:id":421202465,
-    "wof:lastmodified":1607390887,
+    "wof:lastmodified":1608688185,
+    "wof:megacity":1,
     "wof:name":"Kuwait City",
     "wof:parent_id":85673383,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary