### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/542/307/102542307.geojson
+++ b/data/102/542/307/102542307.geojson
@@ -26,6 +26,12 @@
     "name:ben_x_preferred":[
         "\u0995\u09c1\u09af\u09bc\u09c7\u09a4 \u0986\u09a8\u09cd\u09a4\u09b0\u09cd\u099c\u09be\u09a4\u09bf\u0995 \u09ac\u09bf\u09ae\u09be\u09a8\u09ac\u09a8\u09cd\u09a6\u09b0"
     ],
+    "name:ckb_x_preferred":[
+        "\u0641\u0695\u06c6\u06a9\u06d5\u062e\u0627\u0646\u06d5\u06cc \u0646\u06ce\u0648\u0646\u06d5\u062a\u06d5\u0648\u06d5\u06cc\u06cc\u06cc \u06a9\u0648\u0648\u06d5\u06cc\u062a"
+    ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Rhyngwladol Coweit"
+    ],
     "name:deu_x_preferred":[
         "Flughafen Kuwait"
     ],
@@ -56,6 +62,9 @@
     "name:hrv_x_preferred":[
         "Me\u0111unarodna zra\u010dna luka Kuwait"
     ],
+    "name:hun_x_preferred":[
+        "Kuvaiti nemzetk\u00f6zi rep\u00fcl\u0151t\u00e9r"
+    ],
     "name:ind_x_preferred":[
         "Bandar Udara Internasional Kuwait"
     ],
@@ -67,6 +76,9 @@
     ],
     "name:kor_x_preferred":[
         "\ucfe0\uc6e8\uc774\ud2b8 \uad6d\uc81c\uacf5\ud56d"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d15\u0d41\u0d35\u0d48\u0d31\u0d4d\u0d31\u0d4d \u0d05\u0d28\u0d4d\u0d24\u0d3e\u0d30\u0d3e\u0d37\u0d4d\u0d1f\u0d4d\u0d30 \u0d35\u0d3f\u0d2e\u0d3e\u0d28\u0d24\u0d4d\u0d24\u0d3e\u0d35\u0d33\u0d02"
     ],
     "name:mar_x_preferred":[
         "\u0915\u0941\u0935\u0947\u0924 \u0906\u0902\u0924\u0930\u0930\u093e\u0937\u094d\u091f\u094d\u0930\u0940\u092f \u0935\u093f\u092e\u093e\u0928\u0924\u0933"
@@ -95,11 +107,20 @@
     "name:swe_x_preferred":[
         "Kuwait Internationalairport"
     ],
+    "name:tam_x_preferred":[
+        "\u0b95\u0bc1\u0bb5\u0bc8\u0ba4\u0bcd \u0baa\u0ba9\u0bcd\u0ba9\u0bbe\u0b9f\u0bcd\u0b9f\u0bc1 \u0bb5\u0bbe\u0ba9\u0bc2\u0bb0\u0bcd\u0ba4\u0bbf \u0ba8\u0bbf\u0bb2\u0bc8\u0baf\u0bae\u0bcd"
+    ],
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0431\u0438\u043d\u200c\u0430\u043b\u043c\u0438\u043b\u0430\u043b\u04e3 \u043a\u0443\u0432\u0438\u0439\u0442"
     ],
     "name:tha_x_preferred":[
         "\u0e17\u0e48\u0e32\u0e2d\u0e32\u0e01\u0e32\u0e28\u0e22\u0e32\u0e19\u0e19\u0e32\u0e19\u0e32\u0e0a\u0e32\u0e15\u0e34\u0e04\u0e39\u0e40\u0e27\u0e15"
+    ],
+    "name:tur_x_preferred":[
+        "Kuveyt Uluslararas\u0131 Havaliman\u0131"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0443\u0432\u0435\u0439\u0442"
     ],
     "name:vie_x_preferred":[
         "S\u00e2n bay qu\u1ed1c t\u1ebf Kuwait"
@@ -120,11 +141,11 @@
         "state_id":20070168
     },
     "wof:belongsto":[
-        85673389,
+        1729726339,
         102191569,
         85632401,
         421204583,
-        1729726339
+        85673389
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -157,7 +178,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028304,
+    "wof:lastmodified":1690938373,
     "wof:name":"Kuwait International Airport",
     "wof:parent_id":1729726339,
     "wof:placetype":"campus",

--- a/data/172/974/080/3/1729740803.geojson
+++ b/data/172/974/080/3/1729740803.geojson
@@ -21,6 +21,12 @@
     "name:eng_x_preferred":[
         "Sawabir"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0430\u0432\u0430\u0431\u0438\u0440"
+    ],
+    "name:nld_x_preferred":[
+        "Sawabir"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -42,12 +48,12 @@
     "src:geom":"quattroshapes",
     "wd:wordcount":68,
     "wof:belongsto":[
-        85673383,
+        421205053,
         102191569,
         85632401,
         421202465,
         421201553,
-        421205053
+        85673383
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -76,7 +82,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028367,
+    "wof:lastmodified":1690938375,
     "wof:name":"Sawaber",
     "wof:parent_id":421205053,
     "wof:placetype":"microhood",

--- a/data/421/171/567/421171567.geojson
+++ b/data/421/171/567/421171567.geojson
@@ -23,7 +23,13 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0646\u0627\u0621 \u0627\u0644\u0634\u0648\u064a\u062e"
     ],
+    "name:ben_x_preferred":[
+        "\u09ae\u09bf\u09a8\u09be \u0986\u09b2-\u09b6\u09c1\u0993\u09af\u09bc\u09be\u0987\u0996"
+    ],
     "name:eng_x_preferred":[
+        "Shuwaikh Port"
+    ],
+    "name:hau_x_preferred":[
         "Shuwaikh Port"
     ],
     "name:jpn_x_preferred":[
@@ -57,11 +63,11 @@
     "src:lbl_centroid":"mapshaper",
     "wd:wordcount":860,
     "wof:belongsto":[
+        85673383,
         102191569,
         85632401,
         421202465,
-        421201553,
-        85673383
+        421201553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -92,7 +98,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028398,
+    "wof:lastmodified":1690938379,
     "wof:name":"Shuwaikh",
     "wof:parent_id":421202465,
     "wof:placetype":"neighbourhood",

--- a/data/421/181/327/421181327.geojson
+++ b/data/421/181/327/421181327.geojson
@@ -42,7 +42,13 @@
     "name:mzn_x_preferred":[
         "\u062c\u0644\u06cc\u0628 \u0627\u0644\u0634\u06cc\u0648\u062e"
     ],
+    "name:nld_x_preferred":[
+        "Jleeb Al-Shuyoukh"
+    ],
     "name:nno_x_preferred":[
+        "Jleeb Al-Shuyoukh"
+    ],
+    "name:nob_x_preferred":[
         "Jleeb Al-Shuyoukh"
     ],
     "name:pol_x_preferred":[
@@ -114,7 +120,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028339,
+    "wof:lastmodified":1690938378,
     "wof:name":"Jleeb Al-Shuyoukh",
     "wof:parent_id":421204583,
     "wof:placetype":"locality",

--- a/data/421/181/831/421181831.geojson
+++ b/data/421/181/831/421181831.geojson
@@ -38,6 +38,12 @@
     "name:hin_x_preferred":[
         "\u0938\u0930\u094d\u0930\u093e \u0930\u094b\u0917"
     ],
+    "name:ind_x_preferred":[
+        "Penyakit surra"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b9\u30fc\u30e9\u75c5"
+    ],
     "name:pol_x_preferred":[
         "Surra"
     ],
@@ -69,11 +75,11 @@
     "src:lbl_centroid":"mapshaper",
     "wd:wordcount":1148,
     "wof:belongsto":[
+        85673383,
         102191569,
         85632401,
         421202465,
-        421201553,
-        85673383
+        421201553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -104,7 +110,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028364,
+    "wof:lastmodified":1690938377,
     "wof:name":"Surra",
     "wof:parent_id":421202465,
     "wof:placetype":"neighbourhood",

--- a/data/421/184/383/421184383.geojson
+++ b/data/421/184/383/421184383.geojson
@@ -23,8 +23,14 @@
     "name:ara_x_variant":[
         "\u062d\u0648\u0644\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Hawalli"
+    ],
     "name:ceb_x_preferred":[
         "\u1e28awall\u012b"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a7\u03b1\u03bf\u03c5\u03b1\u03bb\u03bb\u03af"
     ],
     "name:eng_x_preferred":[
         "Hawalli"
@@ -34,6 +40,9 @@
     ],
     "name:fas_x_preferred":[
         "\u062d\u0648\u0644\u06cc"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d7\u05d5\u05d5\u05d0\u05dc\u05d9"
     ],
     "name:ind_x_preferred":[
         "Hawalli"
@@ -52,6 +61,12 @@
     ],
     "name:mzn_x_preferred":[
         "\u062d\u0648\u0644\u06cc"
+    ],
+    "name:nno_x_preferred":[
+        "Hawalli"
+    ],
+    "name:nob_x_preferred":[
+        "Hawalli"
     ],
     "name:pol_x_preferred":[
         "Hawalli"
@@ -232,7 +247,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028379,
+    "wof:lastmodified":1690938379,
     "wof:name":"East Hawalli",
     "wof:parent_id":1729718867,
     "wof:placetype":"locality",

--- a/data/421/189/037/421189037.geojson
+++ b/data/421/189/037/421189037.geojson
@@ -39,6 +39,9 @@
     "name:fas_x_preferred":[
         "\u0635\u0628\u0627\u062d \u0627\u0644\u0633\u0627\u0644\u0645"
     ],
+    "name:jpn_x_preferred":[
+        "\u30b5\u30d0\u30fc\u30cf\u30fb\u30a2\u30c3\uff1d\u30b5\u30fc\u30ea\u30e0"
+    ],
     "name:mzn_x_preferred":[
         "\u0635\u0628\u0627\u062d \u0627\u0644\u0633\u0627\u0644\u0645"
     ],
@@ -112,7 +115,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028323,
+    "wof:lastmodified":1690938377,
     "wof:name":"Sabah as Salim",
     "wof:parent_id":421193461,
     "wof:placetype":"locality",

--- a/data/421/189/039/421189039.geojson
+++ b/data/421/189/039/421189039.geojson
@@ -30,6 +30,9 @@
     "name:fas_x_preferred":[
         "\u062c\u0627\u0628\u0631\u06cc\u0647"
     ],
+    "name:fra_x_preferred":[
+        "Jabriya"
+    ],
     "name:lit_x_preferred":[
         "D\u017eabrija"
     ],
@@ -100,7 +103,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028324,
+    "wof:lastmodified":1690938377,
     "wof:name":"Jabriya",
     "wof:parent_id":1729718867,
     "wof:placetype":"locality",

--- a/data/421/190/475/421190475.geojson
+++ b/data/421/190/475/421190475.geojson
@@ -27,8 +27,14 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0633\u0627\u0644\u0645\u064a\u0629"
     ],
+    "name:ast_x_preferred":[
+        "Salmiya"
+    ],
     "name:ceb_x_preferred":[
         "As S\u0101lim\u012byah"
+    ],
+    "name:deu_x_preferred":[
+        "Salmiya"
     ],
     "name:eng_x_preferred":[
         "Abu Fateira"
@@ -41,6 +47,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0633\u0627\u0644\u0645\u06cc\u0647"
+    ],
+    "name:fra_x_preferred":[
+        "Salmiya"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30eb\u30df\u30a2"
@@ -57,6 +66,9 @@
     "name:mzn_x_preferred":[
         "\u0627\u0644\u0633\u0627\u0644\u0645\u06cc\u0647"
     ],
+    "name:nob_x_preferred":[
+        "Salmiya"
+    ],
     "name:pol_x_preferred":[
         "As-Salimija"
     ],
@@ -65,6 +77,9 @@
     ],
     "name:swe_x_preferred":[
         "As S\u0101lim\u012byah"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0421\u0430\u043b\u044c\u043c\u0456\u044f"
     ],
     "name:urd_x_preferred":[
         "\u0633\u0627\u0644\u0645\u06cc\u06c1"
@@ -127,7 +142,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028348,
+    "wof:lastmodified":1690938378,
     "wof:name":"Abu Fateira",
     "wof:parent_id":1729718867,
     "wof:placetype":"locality",

--- a/data/421/190/737/421190737.geojson
+++ b/data/421/190/737/421190737.geojson
@@ -45,6 +45,9 @@
     "name:urd_x_preferred":[
         "\u0631\u0645\u06cc\u062b\u06cc\u06c1"
     ],
+    "name:zho_x_preferred":[
+        "\u9c81\u8fc8\u63d0\u4e9a"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -103,7 +106,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028344,
+    "wof:lastmodified":1690938378,
     "wof:name":"Rumaithiya",
     "wof:parent_id":1729718867,
     "wof:placetype":"locality",

--- a/data/421/192/435/421192435.geojson
+++ b/data/421/192/435/421192435.geojson
@@ -27,6 +27,9 @@
         "Al Murq\u0101b",
         "\u0627\u0644\u0645\u0631\u0642\u0627\u0628"
     ],
+    "name:cat_x_preferred":[
+        "Al Murqab"
+    ],
     "name:ceb_x_preferred":[
         "Al Murq\u0101b"
     ],
@@ -69,11 +72,11 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
+        85673383,
         102191569,
         85632401,
         421202465,
-        421201553,
-        85673383
+        421201553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -106,7 +109,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028359,
+    "wof:lastmodified":1690938376,
     "wof:name":"Al Murq\u00e5b",
     "wof:parent_id":421202465,
     "wof:placetype":"neighbourhood",

--- a/data/421/194/851/421194851.geojson
+++ b/data/421/194/851/421194851.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Safat"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0430\u0444\u0430\u0442"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -43,11 +46,11 @@
     "src:geom":"quattroshapes",
     "wd:wordcount":44,
     "wof:belongsto":[
+        85673383,
         102191569,
         85632401,
         421202465,
-        421201553,
-        85673383
+        421201553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +78,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028362,
+    "wof:lastmodified":1690938376,
     "wof:name":"Safat",
     "wof:parent_id":421202465,
     "wof:placetype":"neighbourhood",

--- a/data/421/202/465/421202465.geojson
+++ b/data/421/202/465/421202465.geojson
@@ -42,6 +42,9 @@
     "name:arc_x_preferred":[
         "\u071f\u0718\u0718\u071d\u072c"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0643\u0648\u064a\u062a"
+    ],
     "name:arz_x_preferred":[
         "\u0645\u062f\u064a\u0646\u0647 \u0627\u0644\u0643\u0648\u064a\u062a"
     ],
@@ -56,6 +59,9 @@
     ],
     "name:bak_x_preferred":[
         "\u04d8\u043b-\u041a\u04af\u0432\u04d9\u0439\u0442"
+    ],
+    "name:ban_x_preferred":[
+        "Kota Kuwait"
     ],
     "name:bcl_x_preferred":[
         "Syudad nin Kuwait"
@@ -111,6 +117,9 @@
     "name:deu_x_preferred":[
         "Kuwait-Stadt"
     ],
+    "name:deu_x_variant":[
+        "Kuweit-Stadt"
+    ],
     "name:dty_x_preferred":[
         "\u0915\u0941\u0935\u0947\u0924 \u0938\u093f\u091f\u0940"
     ],
@@ -141,6 +150,9 @@
     "name:fas_x_preferred":[
         "\u06a9\u0648\u06cc\u062a"
     ],
+    "name:fas_x_variant":[
+        "\u06a9\u0648\u06cc\u062a\u200c\u0634\u0647\u0631"
+    ],
     "name:fin_x_preferred":[
         "Kuwait"
     ],
@@ -149,6 +161,9 @@
     ],
     "name:frp_x_preferred":[
         "Koveyit"
+    ],
+    "name:frr_x_preferred":[
+        "Kuwait-Steed"
     ],
     "name:fry_x_preferred":[
         "Koeweit"
@@ -173,6 +188,9 @@
     ],
     "name:hat_x_preferred":[
         "Kow\u00e8t"
+    ],
+    "name:hau_x_preferred":[
+        "Kuwaiti"
     ],
     "name:heb_x_preferred":[
         "\u05db\u05d5\u05d5\u05d9\u05ea \u05e1\u05d9\u05d8\u05d9"
@@ -284,6 +302,9 @@
     "name:mar_x_preferred":[
         "\u0915\u0941\u0935\u0947\u0924 \u0936\u0939\u0930"
     ],
+    "name:mdf_x_preferred":[
+        "\u042d\u043b\u044c-\u041a\u0443\u0432\u044d\u0439\u0442"
+    ],
     "name:mhr_x_preferred":[
         "\u041a\u0443\u0432\u0435\u0439\u0442"
     ],
@@ -293,11 +314,17 @@
     "name:mlg_x_preferred":[
         "Kuwait City"
     ],
+    "name:mlt_x_preferred":[
+        "Belt tal-Kuwajt"
+    ],
     "name:mon_x_preferred":[
         "\u041a\u0443\u0432\u0435\u0439\u0442 \u0445\u043e\u0442"
     ],
     "name:msa_x_preferred":[
         "Bandar Kuwait"
+    ],
+    "name:mya_x_preferred":[
+        "\u1000\u1030\u101d\u102d\u1010\u103a\u1019\u103c\u102d\u102f\u1037"
     ],
     "name:mzn_x_preferred":[
         "\u0627\u0644\u06a9\u0648\u06cc\u062a"
@@ -356,6 +383,9 @@
     "name:rus_x_preferred":[
         "\u042d\u043b\u044c-\u041a\u0443\u0432\u0435\u0439\u0442"
     ],
+    "name:sat_x_preferred":[
+        "\u1c60\u1c69\u1c63\u1c6e\u1c5b \u1c65\u1c5a\u1c66\u1c5a\u1c68"
+    ],
     "name:sco_x_preferred":[
         "Kuwait Ceety"
     ],
@@ -408,6 +438,9 @@
         "Kuwait Stad",
         "Kuwait"
     ],
+    "name:szl_x_preferred":[
+        "Kuwejt"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bc1\u0bb5\u0bc8\u0ba4\u0bcd \u0ba8\u0b95\u0bb0\u0bae\u0bcd"
     ],
@@ -429,8 +462,14 @@
     "name:tur_x_preferred":[
         "Kuveyt"
     ],
+    "name:udm_x_preferred":[
+        "\u042d\u043b\u044c-\u041a\u0443\u0432\u0435\u0439\u0442"
+    ],
     "name:uig_x_preferred":[
         "\u0643\u06c7\u06cb\u0627\u0626\u0649\u062a \u0634\u06d5\u06be\u0649\u0631\u0649"
+    ],
+    "name:uig_x_variant":[
+        "\u0643\u06c7\u06cb\u06d5\u064a\u062a \u0634\u06d5\u06be\u0649\u0631\u0649"
     ],
     "name:ukr_x_preferred":[
         "\u0415\u043b\u044c-\u041a\u0443\u0432\u0435\u0439\u0442"
@@ -443,6 +482,9 @@
     ],
     "name:uzb_x_preferred":[
         "Al-Quvayt"
+    ],
+    "name:vec_x_preferred":[
+        "Al Kuwait"
     ],
     "name:vep_x_preferred":[
         "El' Kuveit"
@@ -479,6 +521,9 @@
     ],
     "name:zho_x_preferred":[
         "\u79d1\u5a01\u7279\u5e02"
+    ],
+    "name:zho_x_variant":[
+        "\u79d1\u5a01\u7279\u57ce"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Kuwait",
@@ -637,7 +682,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028356,
+    "wof:lastmodified":1690938376,
     "wof:megacity":1,
     "wof:name":"Kuwait City",
     "wof:parent_id":421201553,

--- a/data/421/204/369/421204369.geojson
+++ b/data/421/204/369/421204369.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Kaifan"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u06cc\u0641\u0627\u0646"
+    ],
     "name:nld_x_preferred":[
         "Kaifan"
     ],
@@ -66,11 +69,11 @@
     "src:lbl_centroid":"mapshaper",
     "wd:wordcount":43,
     "wof:belongsto":[
+        85673383,
         102191569,
         85632401,
         421202465,
-        421201553,
-        85673383
+        421201553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -103,7 +106,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028361,
+    "wof:lastmodified":1690938376,
     "wof:name":"Kayfan",
     "wof:parent_id":421202465,
     "wof:placetype":"neighbourhood",

--- a/data/856/324/01/85632401.geojson
+++ b/data/856/324/01/85632401.geojson
@@ -40,6 +40,9 @@
     "name:aka_x_preferred":[
         "Kuwete"
     ],
+    "name:aka_x_variant":[
+        "Kuwait"
+    ],
     "name:als_x_preferred":[
         "Kuwait"
     ],
@@ -50,8 +53,14 @@
     "name:amh_x_variant":[
         "\u12ad\u12cc\u1275"
     ],
+    "name:ami_x_preferred":[
+        "Kuwait"
+    ],
     "name:ang_x_preferred":[
         "Cuwait"
+    ],
+    "name:anp_x_preferred":[
+        "\u0915\u0941\u0935\u0948\u0924"
     ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u0643\u0648\u064a\u062a"
@@ -67,6 +76,9 @@
     "name:arg_x_preferred":[
         "Kuwait"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u0643\u0648\u064a\u062a"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u0643\u0648\u064a\u062a"
     ],
@@ -75,6 +87,9 @@
     ],
     "name:ast_x_preferred":[
         "Kuwait"
+    ],
+    "name:awa_x_preferred":[
+        "\u0915\u0941\u0935\u0947\u0924"
     ],
     "name:azb_x_preferred":[
         "\u06a9\u0648\u06cc\u062a"
@@ -93,6 +108,9 @@
     ],
     "name:bam_x_preferred":[
         "Kow\u025bti"
+    ],
+    "name:ban_x_preferred":[
+        "Kuwait"
     ],
     "name:bar_x_preferred":[
         "Kuwait"
@@ -114,6 +132,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0915\u0941\u0935\u0948\u0924"
+    ],
+    "name:bis_x_preferred":[
+        "Kuwait"
     ],
     "name:bod_x_preferred":[
         "\u0f41\u0f74\u0f0b\u0f5d\u0f72\u0f0b\u0f50\u0f72\u0f0d"
@@ -178,6 +199,9 @@
     "name:cym_x_variant":[
         "Coweit"
     ],
+    "name:dag_x_preferred":[
+        "Kuwait"
+    ],
     "name:dan_x_preferred":[
         "Kuwait"
     ],
@@ -186,6 +210,9 @@
     ],
     "name:deu_x_variant":[
         "Staat Kuwait"
+    ],
+    "name:diq_x_preferred":[
+        "Kuweyt"
     ],
     "name:div_x_preferred":[
         "\u0786\u07aa\u0788\u07ac\u0787\u07a8\u078c\u07aa"
@@ -264,8 +291,14 @@
     "name:ful_x_preferred":[
         "Kuweyti"
     ],
+    "name:ful_x_variant":[
+        "Kuwayti"
+    ],
     "name:gag_x_preferred":[
         "Kuveyt"
+    ],
+    "name:gcr_x_preferred":[
+        "Kow\u00e8yt"
     ],
     "name:gla_x_preferred":[
         "Cubhait"
@@ -284,6 +317,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0915\u0941\u0935\u0947\u0924"
+    ],
+    "name:gpe_x_preferred":[
+        "Kuwait"
     ],
     "name:grn_x_preferred":[
         "Ku\u00e1ite"
@@ -395,6 +431,9 @@
     "name:kan_x_preferred":[
         "\u0c95\u0cc1\u0cb5\u0cc8\u0ca4\u0ccd"
     ],
+    "name:kas_x_preferred":[
+        "\u06a9\u064f\u0648\u06cc\u062a"
+    ],
     "name:kat_x_preferred":[
         "\u10e5\u10e3\u10d5\u10d4\u10d8\u10d7\u10d8"
     ],
@@ -470,6 +509,9 @@
     "name:lit_x_preferred":[
         "Kuveitas"
     ],
+    "name:lld_x_preferred":[
+        "Cueit"
+    ],
     "name:lmo_x_preferred":[
         "Kuwait"
     ],
@@ -491,6 +533,9 @@
     "name:lzh_x_preferred":[
         "\u79d1\u5a01\u7279"
     ],
+    "name:mad_x_preferred":[
+        "Kuwait"
+    ],
     "name:mai_x_preferred":[
         "\u0915\u0941\u0935\u0948\u0924"
     ],
@@ -506,8 +551,14 @@
     "name:mar_x_variant":[
         "\u0915\u0941\u0935\u0948\u0924"
     ],
+    "name:mdf_x_preferred":[
+        "\u041a\u0443\u0432\u044d\u0439\u0442"
+    ],
     "name:mhr_x_preferred":[
         "\u041a\u0443\u0432\u0435\u0439\u0442"
+    ],
+    "name:min_x_preferred":[
+        "Kuwait"
     ],
     "name:mkd_x_preferred":[
         "\u041a\u0443\u0432\u0430\u0458\u0442"
@@ -521,8 +572,14 @@
     "name:mlt_x_preferred":[
         "Kuwajt"
     ],
+    "name:mni_x_preferred":[
+        "\uabc0\uabe8\uabcb\uabe9\uabe0"
+    ],
     "name:mon_x_preferred":[
         "\u041a\u0443\u0432\u0435\u0439\u0442"
+    ],
+    "name:mri_x_preferred":[
+        "K\u016bweiti"
     ],
     "name:msa_x_preferred":[
         "Kuwait"
@@ -665,6 +722,9 @@
     "name:sgs_x_preferred":[
         "Kov\u0117its"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1076\u1030\u1087\u101d\u1035\u1010\u103a\u1088"
+    ],
     "name:sin_x_preferred":[
         "\u0d9a\u0dd4\u0dc0\u0dda\u0da7\u0dca \u0dbb\u0dcf\u0da2\u0dca\u200d\u0dba\u0dba"
     ],
@@ -681,8 +741,17 @@
     "name:sme_x_preferred":[
         "Kuwait"
     ],
+    "name:smn_x_preferred":[
+        "Kuwait"
+    ],
+    "name:sms_x_preferred":[
+        "Kuwaitt"
+    ],
     "name:sna_x_preferred":[
         "Kuwait"
+    ],
+    "name:snd_x_preferred":[
+        "\u06aa\u0648\u064a\u062a"
     ],
     "name:som_x_preferred":[
         "Kuwayt"
@@ -695,6 +764,9 @@
     ],
     "name:sqi_x_variant":[
         "Kuvajt"
+    ],
+    "name:srd_x_preferred":[
+        "Kuwait"
     ],
     "name:srp_x_preferred":[
         "\u041a\u0443\u0432\u0430\u0458\u0442"
@@ -716,6 +788,9 @@
     ],
     "name:szl_x_preferred":[
         "Kuwejt"
+    ],
+    "name:szy_x_preferred":[
+        "Kuwait"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bc1\u0bb5\u0bc8\u0ba4\u0bcd"
@@ -750,10 +825,16 @@
     "name:tir_x_preferred":[
         "\u12ad\u12cc\u1275"
     ],
+    "name:tok_x_preferred":[
+        "ma Kuwasi"
+    ],
     "name:ton_x_preferred":[
         "Kueiti"
     ],
     "name:tpi_x_preferred":[
+        "Kuwait"
+    ],
+    "name:trv_x_preferred":[
         "Kuwait"
     ],
     "name:tuk_x_preferred":[
@@ -786,6 +867,9 @@
     ],
     "name:uzb_x_preferred":[
         "Quvayt"
+    ],
+    "name:vec_x_preferred":[
+        "Kuwait"
     ],
     "name:vep_x_preferred":[
         "Kuveit"
@@ -1061,7 +1145,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1617827450,
+    "wof:lastmodified":1690938373,
     "wof:name":"Kuwait",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/733/83/85673383.geojson
+++ b/data/856/733/83/85673383.geojson
@@ -56,11 +56,20 @@
     "name:ben_x_preferred":[
         "\u0986\u09b2 \u0986\u09b8\u09bf\u09ae\u09be\u09b9"
     ],
+    "name:ben_x_variant":[
+        "\u09b0\u09be\u099c\u09a7\u09be\u09a8\u09c0 \u0997\u09ad\u09b0\u09cd\u09a8\u09b0\u09c7\u099f"
+    ],
     "name:bul_x_preferred":[
         "\u0410\u043b-\u0410\u0441\u0438\u043c\u0430"
     ],
     "name:ceb_x_preferred":[
         "Al Asimah Governorate"
+    ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u0639\u0627\u0633\u06cc\u0645\u06d5"
+    ],
+    "name:deu_x_preferred":[
+        "Gouvernement al-Asima"
     ],
     "name:ell_x_preferred":[
         "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u03a0\u03c1\u03c9\u03c4\u03b5\u03cd\u03bf\u03c5\u03c3\u03b1\u03c2"
@@ -70,7 +79,6 @@
     ],
     "name:eng_x_variant":[
         "Kuwait City",
-        "Al Asimah",
         "Al `Asimah",
         "Al Kuwayt",
         "Al Asimah Governorate",
@@ -153,6 +161,9 @@
     ],
     "name:swe_x_preferred":[
         "Al Asimahguvernementet"
+    ],
+    "name:tam_x_preferred":[
+        "\u0ba4\u0bb2\u0bc8\u0ba8\u0b95\u0bb0 \u0b86\u0bb3\u0bc1\u0ba8\u0bb0\u0b95\u0bae\u0bcd"
     ],
     "name:tur_x_preferred":[
         "El Asime Valili\u011fi"
@@ -298,7 +309,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636497448,
+    "wof:lastmodified":1690938375,
     "wof:name":"Al Asimah",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/89/85673389.geojson
+++ b/data/856/733/89/85673389.geojson
@@ -54,6 +54,9 @@
     "name:ceb_x_preferred":[
         "Mu\u1e29\u0101faz\u0327at al Farw\u0101n\u012byah"
     ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u0641\u06d5\u0631\u0648\u0627\u0646\u06cc\u06d5"
+    ],
     "name:dan_x_preferred":[
         "Al Farwaniyah Governorate"
     ],
@@ -171,6 +174,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb2\u0bcd \u0baa\u0bbe\u0bb0\u0bcd\u0bb5\u0bbe\u0ba9\u0bbf\u0baf \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
+    ],
+    "name:tam_x_variant":[
+        "\u0baa\u0bb0\u0bcd\u0bb5\u0bbe\u0ba9\u0bbf\u0baf\u0bbe \u0b95\u0bb5\u0bb0\u0bcd\u0ba9\u0bb0\u0bc7\u0b9f\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c05\u0c32\u0c4d \u0c2b\u0c30\u0c4d\u0c35\u0c3e\u0c28\u0c3f\u0c2f\u0c3e \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
@@ -323,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636497447,
+    "wof:lastmodified":1690938374,
     "wof:name":"Al Farwaniyah",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/91/85673391.geojson
+++ b/data/856/733/91/85673391.geojson
@@ -51,14 +51,23 @@
     "name:ben_x_preferred":[
         "\u0986\u09b2 \u0986\u09b9\u09ae\u09be\u09a6\u09bf \u0997\u09ad\u09b0\u09cd\u09a8\u09cb\u09b0\u09c7\u099f"
     ],
+    "name:ben_x_variant":[
+        "\u0986\u09b9\u09ae\u09be\u09a6\u09bf \u09aa\u09cd\u09b0\u09b6\u09be\u09b8\u09a8\u09bf\u0995 \u0985\u099e\u09cd\u099a\u09b2"
+    ],
     "name:bul_x_preferred":[
         "\u0410\u043b-\u0410\u0445\u043c\u0430\u0434\u0438"
+    ],
+    "name:bul_x_variant":[
+        "\u0410\u0445\u043c\u0430\u0434\u0438"
     ],
     "name:cat_x_preferred":[
         "Governaci\u00f3 d'Ahmad\u00ed"
     ],
     "name:ceb_x_preferred":[
         "Mu\u1e29\u0101faz\u0327at al A\u1e29mad\u012b"
+    ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u0626\u06d5\u062d\u0645\u06d5\u062f\u06cc"
     ],
     "name:dan_x_preferred":[
         "Al Ahmadi Governorate"
@@ -91,6 +100,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab2 \u0a85\u0ab9\u0aae\u0aa6\u0ac0 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05dc-\u05d0\u05d7\u05de\u05d3\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u0905\u0932 \u0905\u0939\u092e\u0926\u0940 \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -169,6 +181,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb2\u0bcd \u0b85\u0bb9\u0bcd\u0bae\u0b9f\u0bbf \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bbe\u0b9f\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b85\u0bb2\u0bcd \u0b85\u0bb9\u0bcd\u0bae\u0ba4\u0bbf \u0b95\u0bb5\u0bb0\u0bcd\u0ba9\u0bb0\u0bc7\u0b9f\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c05\u0c32\u0c4d \u0c05\u0c39\u0c4d\u0c2e\u0c26\u0c3f \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
@@ -320,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636497447,
+    "wof:lastmodified":1690938374,
     "wof:name":"Al Ahmadi",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/95/85673395.geojson
+++ b/data/856/733/95/85673395.geojson
@@ -52,6 +52,9 @@
     "name:ceb_x_preferred":[
         "Mu\u1e29\u0101faz\u0327at Mub\u0101rak al Kab\u012br"
     ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u0645\u0648\u0628\u0627\u0631\u06d5\u06a9 \u0626\u06d5\u0644\u06a9\u06d5\u0628\u06cc\u0631"
+    ],
     "name:dan_x_preferred":[
         "Mubarak Al-Kabeer Governorate"
     ],
@@ -78,6 +81,9 @@
     ],
     "name:fra_x_preferred":[
         "Gouvernorat de Mubarak Al-Kabeer"
+    ],
+    "name:fra_x_variant":[
+        "Mubarak Al-Kabeer"
     ],
     "name:guj_x_preferred":[
         "\u0aae\u0ac1\u0aac\u0abe\u0ab0\u0a95 \u0a85\u0ab2-\u0a95\u0aac\u0ac0\u0ab0 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
@@ -165,6 +171,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc1\u0baa\u0bbe\u0bb0\u0b95\u0bcd \u0b85\u0bb4 -\u0b95\u0baa\u0bc0\u0bb0\u0bcd \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
+    ],
+    "name:tam_x_variant":[
+        "\u0bae\u0bc1\u0baa\u0bbe\u0bb0\u0b95\u0bcd \u0b85\u0bb4 -\u0b95\u0baa\u0bc0\u0bb0\u0bcd \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7\u0b9f\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c41\u0c2c\u0c3e\u0c30\u0c15\u0c4d \u0c05\u0c32\u0c4d-\u0c15\u0c2c\u0c40\u0c30\u0c4d \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
@@ -312,7 +321,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636497447,
+    "wof:lastmodified":1690938374,
     "wof:name":"Mubarak Al-Kabeer",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/99/85673399.geojson
+++ b/data/856/733/99/85673399.geojson
@@ -43,6 +43,9 @@
         "\u0645\u064f\u062d\u064e\u0627\u0641\u064e\u0638\u064e\u0629 \u0627\u0644\u062c\u064e\u0647\u0652\u0631\u064e\u0627\u0621",
         "\u0645\u062d\u0627\u0641\u0638\u0629 \u0627\u0644\u062c\u0647\u0631\u0627\u0621"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062d\u0627\u0641\u0638\u0647 \u0627\u0644\u062c\u0647\u0631\u0627\u0621"
+    ],
     "name:ast_x_preferred":[
         "Al Jahra"
     ],
@@ -52,6 +55,9 @@
     "name:ben_x_preferred":[
         "\u0986\u09b2 \u099c\u09be\u09b9\u09b0\u09be\u09b9"
     ],
+    "name:ben_x_variant":[
+        "\u099c\u09be\u09b9\u09b0\u09be \u0997\u09ad\u09b0\u09cd\u09a8\u09b0\u09c7\u099f"
+    ],
     "name:bul_x_preferred":[
         "\u0414\u0436\u0430\u0445\u0440\u0430"
     ],
@@ -60,6 +66,9 @@
     ],
     "name:ceb_x_preferred":[
         "Mu\u1e29\u0101faz\u0327at al Jahr\u0101'"
+    ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u062c\u06d5\u06be\u0631\u0627"
     ],
     "name:deu_x_preferred":[
         "Gouvernement al-Dschahra"
@@ -71,7 +80,6 @@
         "Al Jahrah"
     ],
     "name:eng_x_variant":[
-        "Al Jahrah",
         "Jahra",
         "Al Jahra Governorate"
     ],
@@ -158,6 +166,9 @@
     ],
     "name:swe_x_preferred":[
         "Mu\u1e29\u0101faz\u0327at al Jahr\u0101'"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b85\u0bb2\u0bcd \u0b9c\u0bb9\u0bcd\u0bb0\u0bbe \u0b86\u0bb3\u0bc1\u0ba8\u0bb0\u0b95\u0bae\u0bcd"
     ],
     "name:tur_x_preferred":[
         "El Cehre"
@@ -310,7 +321,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636497448,
+    "wof:lastmodified":1690938375,
     "wof:name":"Al Jahrah",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/734/05/85673405.geojson
+++ b/data/856/734/05/85673405.geojson
@@ -54,6 +54,9 @@
     "name:ceb_x_preferred":[
         "Mu\u1e29\u0101faz\u0327at \u1e28awall\u012b"
     ],
+    "name:ckb_x_preferred":[
+        "\u067e\u0627\u0631\u06ce\u0632\u06af\u0627\u06cc \u062d\u0648\u0648\u0644\u06cc"
+    ],
     "name:dan_x_preferred":[
         "Hawalli Governorate"
     ],
@@ -93,6 +96,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0540\u0561\u057e\u0561\u056c\u056b"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0540\u0561\u0578\u0582\u0561\u056c\u056b"
     ],
     "name:ind_x_preferred":[
         "Kegubernuran Hawalli"
@@ -156,6 +162,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bb9\u0bb5\u0bb2\u0bcd\u0bb2\u0bbf \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb9\u0bb5\u0bb2\u0bcd\u0bb2\u0bbf \u0b86\u0bb3\u0bc1\u0ba8\u0bb0\u0b95\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c39\u0c35\u0c3e\u0c32\u0c3f \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
@@ -309,7 +318,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636497447,
+    "wof:lastmodified":1690938374,
     "wof:name":"Hawalli",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/859/030/27/85903027.geojson
+++ b/data/859/030/27/85903027.geojson
@@ -31,7 +31,11 @@
         "\u0627\u0644\u0635\u0644\u064a\u0628\u064a\u062e\u0627\u062a"
     ],
     "name:ara_x_variant":[
-        "\u0627\u064e\u0644\u0635\u064f\u0651\u0644\u064e\u064a\u0652\u0628\u0650\u064a\u062e\u064e\u0627\u062a"
+        "\u0627\u064e\u0644\u0635\u064f\u0651\u0644\u064e\u064a\u0652\u0628\u0650\u064a\u062e\u064e\u0627\u062a",
+        "\u0627\u0644\u0635\u0644\u064a\u0628\u062e\u0627\u062a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0647 \u0627\u0644\u0635\u0644\u064a\u0628\u064a\u062e\u0627\u062a"
     ],
     "name:deu_x_preferred":[
         "Sulaibikhat"
@@ -89,11 +93,11 @@
     "src:lbl_centroid":"mapshaper",
     "wd:wordcount":120,
     "wof:belongsto":[
+        85673383,
         102191569,
         85632401,
         421202465,
-        421201553,
-        85673383
+        421201553
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -126,7 +130,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028361,
+    "wof:lastmodified":1690938373,
     "wof:name":"As Sulaybikhat",
     "wof:parent_id":421202465,
     "wof:placetype":"neighbourhood",

--- a/data/890/439/989/890439989.geojson
+++ b/data/890/439/989/890439989.geojson
@@ -29,6 +29,9 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u062c\u0647\u0631\u0627\u0621"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062c\u0647\u0631\u0627\u0621"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09b2 \u099c\u09be\u09be\u09b0\u09be"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05dc\u05d2'\u05d4\u05e8\u05d0"
+    ],
+    "name:heb_x_variant":[
+        "\u05d0\u05dc-\u05d2'\u05d4\u05e8\u05d0\u05d0"
     ],
     "name:hin_x_preferred":[
         "\u0905\u0932 \u091c\u0939\u0930\u093e"
@@ -208,7 +214,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614028399,
+    "wof:lastmodified":1690938379,
     "wof:name":"Al Jahra",
     "wof:parent_id":421170031,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.