### PR TITLE
kw concordances, placetype local, and more

### DIFF
--- a/data/172/971/885/9/1729718859.geojson
+++ b/data/172/971/885/9/1729718859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.415752,
-    "geom:area_square_m":4504164417.673628,
+    "geom:area_square_m":4504164417.673404,
     "geom:bbox":"47.497992,28.524446,48.431641,29.208789",
     "geom:latitude":28.817898,
     "geom:longitude":47.951182,
@@ -213,7 +213,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8706c166052f4b1ead2149f79ac2bd55",
+    "wof:geomhash":"14e3cdad666da6588c5d8c1932f4cd3a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -229,7 +229,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636497448,
+    "wof:lastmodified":1695886736,
     "wof:name":"Al Ahmadi",
     "wof:parent_id":85673391,
     "wof:placetype":"county",

--- a/data/172/971/886/7/1729718867.geojson
+++ b/data/172/971/886/7/1729718867.geojson
@@ -209,7 +209,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886736,
     "wof:name":"Hawalli",
     "wof:parent_id":85673405,
     "wof:placetype":"county",

--- a/data/421/170/031/421170031.geojson
+++ b/data/421/170/031/421170031.geojson
@@ -158,7 +158,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886736,
     "wof:name":"Al Jahrah",
     "wof:parent_id":85673399,
     "wof:placetype":"county",

--- a/data/421/193/461/421193461.geojson
+++ b/data/421/193/461/421193461.geojson
@@ -98,7 +98,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886736,
     "wof:name":"Mubarak Al-Kabeer",
     "wof:parent_id":85673395,
     "wof:placetype":"county",

--- a/data/421/201/553/421201553.geojson
+++ b/data/421/201/553/421201553.geojson
@@ -461,7 +461,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886736,
     "wof:name":"Al Asimah",
     "wof:parent_id":85673383,
     "wof:placetype":"county",

--- a/data/421/204/583/421204583.geojson
+++ b/data/421/204/583/421204583.geojson
@@ -101,7 +101,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886736,
     "wof:name":"Al Farwaniyah",
     "wof:parent_id":85673389,
     "wof:placetype":"county",

--- a/data/856/324/01/85632401.geojson
+++ b/data/856/324/01/85632401.geojson
@@ -1114,6 +1114,7 @@
         "hasc:id":"KW",
         "icao:code":"9K",
         "ioc:id":"KUW",
+        "iso:code":"KW",
         "itu:id":"KWT",
         "loc:id":"n80053139",
         "m49:code":"414",
@@ -1128,6 +1129,7 @@
         "wk:page":"Kuwait",
         "wmo:id":"KW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KW",
     "wof:country_alpha3":"KWT",
     "wof:geom_alt":[
@@ -1149,7 +1151,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639522,
+    "wof:lastmodified":1695881177,
     "wof:name":"Kuwait",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/733/83/85673383.geojson
+++ b/data/856/733/83/85673383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017341,
-    "geom:area_square_m":186883262.606636,
+    "geom:area_square_m":186883262.606621,
     "geom:bbox":"47.785092,28.676111,48.777943,29.489611",
     "geom:latitude":29.358939,
     "geom:longitude":48.029579,
@@ -282,11 +282,13 @@
         "gn:id":285788,
         "gp:id":20070169,
         "hasc:id":"KW.KU",
+        "iso:code":"KW-KU",
         "iso:id":"KW-KU",
         "qs_pg:id":891476,
         "wd:id":"Q1046645",
         "wk:page":"Capital_Governorate_(Kuwait)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421201553
     ],
@@ -294,7 +296,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e0e6db0867ca6e56f4e85c6b6144678",
+    "wof:geomhash":"bbd21ea6665f35208a860443776d5d86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938375,
+    "wof:lastmodified":1695884852,
     "wof:name":"Al Asimah",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/89/85673389.geojson
+++ b/data/856/733/89/85673389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017284,
-    "geom:area_square_m":186493137.189483,
+    "geom:area_square_m":186493137.189482,
     "geom:bbox":"47.805606,29.179906,48.008525,29.304015",
     "geom:latitude":29.237931,
     "geom:longitude":47.918634,
@@ -301,12 +301,14 @@
         "gn:id":285816,
         "gp:id":20070168,
         "hasc:id":"KW.FA",
+        "iso:code":"KW-FA",
         "iso:id":"KW-FA",
         "qs_pg:id":1154066,
         "unlc:id":"KW-FA",
         "wd:id":"Q1072757",
         "wk:page":"Farwaniya_Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421204583
     ],
@@ -314,7 +316,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa6f869746911306dae44499b656c473",
+    "wof:geomhash":"df7079b6d1687a4c94b139366739cfd0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938374,
+    "wof:lastmodified":1695884852,
     "wof:name":"Al Farwaniyah",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/91/85673391.geojson
+++ b/data/856/733/91/85673391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.415752,
-    "geom:area_square_m":4504164417.673508,
+    "geom:area_square_m":4504164417.673552,
     "geom:bbox":"47.497992,28.524446,48.431641,29.208789",
     "geom:latitude":28.817898,
     "geom:longitude":47.951182,
@@ -308,11 +308,13 @@
         "gn:id":285841,
         "gp:id":20070166,
         "hasc:id":"KW.AH",
+        "iso:code":"KW-AH",
         "iso:id":"KW-AH",
         "qs_pg:id":1154064,
         "wd:id":"Q552354",
         "wk:page":"Ahmadi_Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1729718867
     ],
@@ -320,7 +322,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"612e057c6991337fd1b75a61882b05f3",
+    "wof:geomhash":"607e619f362feca6d814f4d5a0753c9e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938374,
+    "wof:lastmodified":1695884852,
     "wof:name":"Al Ahmadi",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/95/85673395.geojson
+++ b/data/856/733/95/85673395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009509,
-    "geom:area_square_m":102613482.045006,
+    "geom:area_square_m":102613482.045004,
     "geom:bbox":"47.987895,29.172382,48.119712,29.270702",
     "geom:latitude":29.221164,
     "geom:longitude":48.051522,
@@ -294,11 +294,13 @@
         "gn:id":7733358,
         "gp:id":55943079,
         "hasc:id":"KW.MU",
+        "iso:code":"KW-MU",
         "iso:id":"KW-MU",
         "qs_pg:id":1111551,
         "wd:id":"Q913370",
         "wk:page":"Mubarak_Al-Kabeer_Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421193461
     ],
@@ -306,7 +308,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01f9e327f4294b48de33fa54f22d1e44",
+    "wof:geomhash":"778341cf25e6c14cd23f862c56bfcb42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938374,
+    "wof:lastmodified":1695884852,
     "wof:name":"Mubarak Al-Kabeer",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/733/99/85673399.geojson
+++ b/data/856/733/99/85673399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.145648,
-    "geom:area_square_m":12323077784.681065,
+    "geom:area_square_m":12323077784.680893,
     "geom:bbox":"46.55304,28.966039,48.38039,30.103699",
     "geom:latitude":29.552232,
     "geom:longitude":47.473571,
@@ -293,12 +293,14 @@
         "gn:id":285798,
         "gp:id":20070165,
         "hasc:id":"KW.JA",
+        "iso:code":"KW-JA",
         "iso:id":"KW-JA",
         "qs_pg:id":1154063,
         "unlc:id":"KW-JA",
         "wd:id":"Q405701",
         "wk:page":"Jahra_Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421170031
     ],
@@ -306,7 +308,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5bdeb98e692fe81c316ee898c02a4acd",
+    "wof:geomhash":"480e78f55d0241e3e11b931fb41dd729",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938375,
+    "wof:lastmodified":1695884852,
     "wof:name":"Al Jahrah",
     "wof:parent_id":85632401,
     "wof:placetype":"region",

--- a/data/856/734/05/85673405.geojson
+++ b/data/856/734/05/85673405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007864,
-    "geom:area_square_m":84794060.227532,
+    "geom:area_square_m":84794060.227526,
     "geom:bbox":"47.979042,29.264523,48.102101,29.360688",
     "geom:latitude":29.305571,
     "geom:longitude":48.043579,
@@ -291,11 +291,13 @@
         "gn:id":285628,
         "gp:id":20070167,
         "hasc:id":"KW.HW",
+        "iso:code":"KW-HA",
         "iso:id":"KW-HA",
         "qs_pg:id":1154065,
         "wd:id":"Q747432",
         "wk:page":"Hawalli_Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1729718859
     ],
@@ -303,7 +305,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"19e32216ddc45e71a426298eeec3b7a8",
+    "wof:geomhash":"a8c23ec61a9835c6f503b8fc652211f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690938374,
+    "wof:lastmodified":1695884852,
     "wof:name":"Hawalli",
     "wof:parent_id":85632401,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.